### PR TITLE
Removed an unused variable name

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -157,7 +157,7 @@ public class proxy : IHttpHandler {
                 String checkValidUri = new UriBuilder(requestReferer.StartsWith("//") ? requestReferer.Substring(requestReferer.IndexOf("//") + 2) : requestReferer).Host;
 
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 log(TraceLevel.Warning, "Proxy is being used from an invalid referer: " + context.Request.Headers["referer"]);
                 sendErrorResponse(context.Response, "Error verifying referer. ", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);


### PR DESCRIPTION
The way the code currently is, people pulling in this file will have a new warning in their project.  Seems like a library should try not to generate warnings in other peoples' projects.